### PR TITLE
✨ feat(route): allows duplicate routes across users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@
 
 - Code reorganisation, a lot of code has moved, please review the following PRs accordingly [#1444](https://github.com/juanfont/headscale/pull/1444)
 
+## 0.22.3-rr (2023-XX-XX)
+
 ### Changes
 - Set max open and idle connections for postgres
+- Allows conflicting subnet ranges across users
 
 ## 0.22.3 (2023-05-12)
 


### PR DESCRIPTION
### Description
Headscale follows tailscale control server architecture where if more than one subnet router irrespective of the user it belongs to,  tries to advertise the same subnet range, only one of them can become a primary router. This is problematic for rapyuta.io VPN use cases where multiple warehouses aka users/namespaces in control server terminology can use the same subnet ranges.

This PR tries to solve this use case by checking conflicting subnet ranges within a namespace/user scope instead of all the users/namespaces.

Wrike:
- https://www.wrike.com/open.htm?id=1259382758
- https://www.wrike.com/open.htm?id=1258751906

<!-- Please tick if the following things apply. You… -->

- [x] read the [CONTRIBUTING guidelines](README.md#contributing)
- [x] raised a GitHub issue or discussed it on the projects chat beforehand
- [x] added unit tests
- [x] added integration tests
- [x] updated documentation if needed
- [x] updated CHANGELOG.md

<!-- If applicable, please reference the issue using `Fixes #XXX` and add tests to cover your new code. -->
