### PR TITLE
🐛 fix(routes): corrects the logic in handlePrimarySubnetFailover

### DIFF
--- a/.github/workflows/build-alpine.yml
+++ b/.github/workflows/build-alpine.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_VERSION: "v0.22.3-dev"
+  BUILD_VERSION: "v0.22.4-rr"
   DOCKER_CLI_EXPERIMENTAL: enabled
 
 permissions: read-all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@
 
 - Code reorganisation, a lot of code has moved, please review the following PRs accordingly [#1444](https://github.com/juanfont/headscale/pull/1444)
 
-## 0.22.3-rr (2023-XX-XX)
+## 0.22.4-rr (2024-01-11)
+### Fixed
+- Subnet failover handler checks for user ID when finding new primary route 
 
+## 0.22.3-rr (2023-XX-28)
 ### Changes
 - Set max open and idle connections for postgres
 - Allows conflicting subnet ranges across users

--- a/hscontrol/routes.go
+++ b/hscontrol/routes.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"net/netip"
 
-	v1 "github.com/juanfont/headscale/gen/go/headscale/v1"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gorm.io/gorm"
+
+	v1 "github.com/juanfont/headscale/gen/go/headscale/v1"
 )
 
 const (
@@ -211,7 +212,7 @@ func (h *Headscale) isUniquePrefix(route Route) bool {
 	for _, r := range routes {
 		// Return false, if there are more than one uniquePrefix for the same
 		// user. Else, true. This allows having the same prefix for two users.
-		if route.Machine.UserID == r.Machine.UserID && route.Machine.isOnline() {
+		if route.Machine.UserID == r.Machine.UserID && r.Machine.isOnline() {
 			return false
 		}
 	}
@@ -367,7 +368,7 @@ func (h *Headscale) handlePrimarySubnetFailover() error {
 
 			var newPrimaryRoute *Route
 			for pos, r := range newPrimaryRoutes {
-				if r.Machine.isOnline() {
+				if r.Machine.UserID == route.Machine.UserID && r.Machine.isOnline() {
 					newPrimaryRoute = &newPrimaryRoutes[pos]
 
 					break


### PR DESCRIPTION
### Description
This PR fixes a couple of things
- The `isUniquePrefix` was checking the state of the incorrect route machine
- The `handlePrimarySubnetFailover` function was not checking for user ID when finding the new primary route for failover