### PR TITLE
fix(hscontrol): fixes high cpu usage issue during node conn/disconn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # CHANGELOG
 
+
 ## 0.23.0 (2023-XX-XX)
 
 ### BREAKING
 
 - Code reorganisation, a lot of code has moved, please review the following PRs accordingly [#1444](https://github.com/juanfont/headscale/pull/1444)
+
+## 0.22.5-rr (2024-05-02)
+### Fixed
+- High CPU consumption during multiple machines/nodes connect/disconnect in tailnet
 
 ## 0.22.4-rr (2024-01-11)
 ### Fixed

--- a/hscontrol/protocol_common_poll.go
+++ b/hscontrol/protocol_common_poll.go
@@ -146,7 +146,7 @@ func (h *Headscale) handlePollCommon(
 
 	// There has been an update to _any_ of the nodes that the other nodes would
 	// need to know about
-	h.setLastStateChangeToNow()
+	h.setLastStateChangeToNow(machine.User)
 
 	// The request is not ReadOnly, so we need to set up channels for updating
 	// peers via longpoll
@@ -322,9 +322,9 @@ func (h *Headscale) pollNetMapStream(
 				Str("channel", "pollData").
 				Int("bytes", len(data)).
 				Msg("Data from pollData channel written successfully")
-				// TODO(kradalby): Abstract away all the database calls, this can cause race conditions
-				// when an outdated machine object is kept alive, e.g. db is update from
-				// command line, but then overwritten.
+			// TODO(kradalby): Abstract away all the database calls, this can cause race conditions
+			// when an outdated machine object is kept alive, e.g. db is update from
+			// command line, but then overwritten.
 			err = h.UpdateMachineFromDatabase(machine)
 			if err != nil {
 				log.Error().
@@ -406,9 +406,9 @@ func (h *Headscale) pollNetMapStream(
 				Str("channel", "keepAlive").
 				Int("bytes", len(data)).
 				Msg("Keep alive sent successfully")
-				// TODO(kradalby): Abstract away all the database calls, this can cause race conditions
-				// when an outdated machine object is kept alive, e.g. db is update from
-				// command line, but then overwritten.
+			// TODO(kradalby): Abstract away all the database calls, this can cause race conditions
+			// when an outdated machine object is kept alive, e.g. db is update from
+			// command line, but then overwritten.
 			err = h.UpdateMachineFromDatabase(machine)
 			if err != nil {
 				log.Error().
@@ -575,9 +575,9 @@ func (h *Headscale) pollNetMapStream(
 				Str("handler", "PollNetMapStream").
 				Str("machine", machine.Hostname).
 				Msg("The client has closed the connection")
-				// TODO: Abstract away all the database calls, this can cause race conditions
-				// when an outdated machine object is kept alive, e.g. db is update from
-				// command line, but then overwritten.
+			// TODO: Abstract away all the database calls, this can cause race conditions
+			// when an outdated machine object is kept alive, e.g. db is update from
+			// command line, but then overwritten.
 			err := h.UpdateMachineFromDatabase(machine)
 			if err != nil {
 				log.Error().

--- a/hscontrol/routes.go
+++ b/hscontrol/routes.go
@@ -313,7 +313,7 @@ func (h *Headscale) handlePrimarySubnetFailover() error {
 		log.Error().Err(err).Msg("error getting routes")
 	}
 
-	routesChanged := false
+	usersChanged := make(map[string]User, 0)
 	for pos, route := range routes {
 		if route.isExitRoute() {
 			continue
@@ -333,9 +333,7 @@ func (h *Headscale) handlePrimarySubnetFailover() error {
 
 					return err
 				}
-
-				routesChanged = true
-
+				usersChanged[route.Machine.User.Name] = route.Machine.User
 				continue
 			}
 		}
@@ -408,12 +406,11 @@ func (h *Headscale) handlePrimarySubnetFailover() error {
 				return err
 			}
 
-			routesChanged = true
+			usersChanged[route.Machine.User.Name] = route.Machine.User
 		}
 	}
-
-	if routesChanged {
-		h.setLastStateChangeToNow()
+	for _, user := range usersChanged {
+		h.setLastStateChangeToNow(user)
 	}
 
 	return nil


### PR DESCRIPTION
This PR fixes high cpu usage observed during times when a node connects/disconnects from tailnet. Since in rapyuta.io we dont allow users to access across project nodes, we therefore limit tailnet change propagation to a particular project only. 
